### PR TITLE
Fix api specs

### DIFF
--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -1,4 +1,4 @@
 Analytics = Segment::Analytics.new({
-  write_key: ENV['segment_io'],
+  write_key: ENV['segment_io'] || 'test',
   on_error: Proc.new { |status, msg| print msg }
 })

--- a/spec/api/alpha/applications_spec.rb
+++ b/spec/api/alpha/applications_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe "Alpha::Applications", :type => :request do
       context "with valid attributes" do
         it "creates a new application" do
           expect{
-            post "http://api.vcap.me:3000/v1/applications?access_token=#{@token.token}", application: FactoryGirl.attributes_for(:application), :format => :json
-          } .to change(Application, :count).by(0)
+            post "http://api.vcap.me:3000/v1/applications?access_token=#{@token.token}", FactoryGirl.attributes_for(:application), :format => :json
+          } .to change(Application, :count).by(1)
         end
 
         it "creates a new application, making sure response is #201" do
@@ -89,23 +89,19 @@ RSpec.describe "Alpha::Applications", :type => :request do
 
       context "valid attributes" do
         it "located the requested @application" do
-          #put "http://api.vcap.me:3000/v1/applications/1", application: FactoryGirl.attributes_for(:application), :format => :json
-          #response.status.should eq(200)
+          put "http://api.vcap.me:3000/v1/applications/1?access_token=#{@token.token}", FactoryGirl.attributes_for(:application), :format => :json
+          response.status.should eq(200)
         end
 
         it "changes @application's attributes" do
-          #put "http://api.vcap.me:3000/v1/applications/1?access_token=#{@token.token}", application: FactoryGirl.attributes_for(:application, reimbursement_needed: true), :format => :json
-          #@application.reload
-          #@application.reimbursement_needed.should eq(true)
+          put "http://api.vcap.me:3000/v1/applications/1?access_token=#{@token.token}", FactoryGirl.attributes_for(:application, reimbursement_needed: true), :format => :json
+          @application.reload
+          @application.reimbursement_needed.should eq(true)
         end
 
         it "sends a 200 if updated application if correct_user" do
-          if @application.user_id == user.id
-            #put "http://api.vcap.me:3000/v1/applications/1?access_token=#{@token.token}", application: FactoryGirl.attributes_for(:application), :format => :json
-            #response.status.should eq(200)
-          else
-            #response.status.should eq(401)
-          end
+          put "http://api.vcap.me:3000/v1/applications/1?access_token=#{@token.token}", FactoryGirl.attributes_for(:application), :format => :json
+          response.status.should eq(200)
         end
       end
 


### PR DESCRIPTION
In your API tests you can examine the response:

```ruby
puts response.body
```

I modified one of the tests:

``` ruby
post "http://api.vcap.me:3000/v1/applications?access_token=#{@token.token}", application: FactoryGirl.attributes_for(:application), :format => :json
puts response.body
```

And it returned:

```json
{"error":"reimbursement_needed is missing, profile_id is missing, hackathon_id is missing"}
```

This is because you're posting these fields under `application`, so the server gets `params[:application][:hackathon_id]`, not just `params[:hackathon_id]`. You can decide to go either way, but obviously it needs to be consistent.

Closes #25.